### PR TITLE
Commands and suffixes are no longer case sensitive

### DIFF
--- a/main.js
+++ b/main.js
@@ -279,8 +279,8 @@ bot.on("disconnected", function () {
 
 bot.on("message", function (msg) {
     if (msg.author != bot.user && msg.content.toLowerCase().startsWith(bot.user) && msg.content.split(bot.user)[1] != "") {
-        var cmdTxt = msg.content.split(" ")[1];
-        var suffix = msg.content.substring(cmdTxt.length + bot.user.mention().length + 2);
+        var cmdTxt = msg.content.split(" ")[1].toLowerCase();
+        var suffix = msg.content.substring(cmdTxt.length + bot.user.mention().length + 2).toLowerCase();
 
         if (cmdTxt === "help") {
             bot.sendMessage(msg.author, "Here is a list of commands:", function () {


### PR DESCRIPTION
Added `.toLowerCase()` to the `cmdTxt` and `suffix` variables in the `message` event.
